### PR TITLE
rename packages that conflict with stdlib

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,12 +1,12 @@
-// Package http provides utilities on top of the net/http package.
-package http
+// Package httputil provides utilities on top of the net/http package.
+package httputil
 
 import (
 	"crypto/tls"
 	"net/http"
 	"time"
 
-	ktls "github.com/kolide/kit/tls"
+	"github.com/kolide/kit/tlsutil"
 )
 
 // Option configures an HTTP Server.
@@ -37,7 +37,7 @@ func NewServer(addr string, h http.Handler, opts ...Option) *http.Server {
 
 	// set a strict TLS config by default.
 	if srv.TLSConfig == nil {
-		srv.TLSConfig = ktls.NewConfig()
+		srv.TLSConfig = tlsutil.NewConfig()
 	}
 
 	return &srv

--- a/httputil/middleware.go
+++ b/httputil/middleware.go
@@ -1,4 +1,4 @@
-package http
+package httputil
 
 import "net/http"
 

--- a/httputil/middleware_example_test.go
+++ b/httputil/middleware_example_test.go
@@ -1,4 +1,4 @@
-package http
+package httputil
 
 import (
 	"fmt"

--- a/tlsutil/tlsutil.go
+++ b/tlsutil/tlsutil.go
@@ -1,5 +1,5 @@
-// Package tls provides utilities on top of the standard library TLS package.
-package tls
+// Package tlsutil provides utilities on top of the standard library TLS package.
+package tlsutil
 
 import (
 	"crypto/tls"

--- a/tlsutil/tlsutil_test.go
+++ b/tlsutil/tlsutil_test.go
@@ -1,4 +1,4 @@
-package tls
+package tlsutil
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
renamed packages which have an equivalent name in stdlib(tls, http)
to have a util suffix.

Closes #8 

I'm ok with this solution if you are: @zwass @marpaia 