### PR TITLE
env: add Duration function

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -14,7 +14,11 @@ Example:
 */
 package env
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"time"
+)
 
 // String returns the environment variable value specified by the key parameter,
 // otherwise returning a default value if set.
@@ -30,6 +34,22 @@ func String(key, def string) string {
 func Bool(key string, def bool) bool {
 	if env := os.Getenv(key); env == "true" || env == "TRUE" || env == "1" {
 		return true
+	}
+	return def
+}
+
+// Duration returns the environment variable value specified by the key parameter,
+// otherwise returning a default value if set.
+// If the time.Duration value cannot be parsed, Duration will exit the program
+// with an error status.
+func Duration(key string, def time.Duration) time.Duration {
+	if env, ok := os.LookupEnv(key); ok {
+		t, err := time.ParseDuration(env)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "env: parse time.Duration from flag: %s\n", err)
+			os.Exit(1)
+		}
+		return t
 	}
 	return def
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -4,7 +4,38 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestDuration(t *testing.T) {
+	var tests = []struct {
+		value time.Duration
+	}{
+		{value: 1 * time.Second},
+		{value: 1 * time.Minute},
+		{value: 1 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value.String(), func(t *testing.T) {
+			key := strings.ToUpper(tt.value.String())
+			if err := os.Setenv(key, tt.value.String()); err != nil {
+				t.Fatalf("failed to set env var %s for test: %s\n", key, err)
+			}
+
+			def := 10 * time.Minute
+			if have, want := Duration(key, def), tt.value; have != want {
+				t.Errorf("have %s, want %s", have, want)
+			}
+		})
+	}
+
+	// test default value
+	def := 10 * time.Minute
+	if have, want := Duration("TEST_DEFAULT", def), def; have != want {
+		t.Errorf("have %s, want %s", have, want)
+	}
+}
 
 func TestString(t *testing.T) {
 	var tests = []struct {


### PR DESCRIPTION
Add new Duration function that returns a time.Duration from environment.

Not sure about the error handling here. Any alternative suggestions?