### PR TITLE
add an optional build id to versions

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -34,6 +34,7 @@ var (
 	goVersion = "unknown"
 	buildDate = "unknown"
 	buildUser = "unknown"
+	buildID   = "" // intentionally left blank
 	appName   = "unknown"
 )
 
@@ -45,6 +46,7 @@ type Info struct {
 	GoVersion string `json:"go_version"`
 	BuildDate string `json:"build_date"`
 	BuildUser string `json:"build_user"`
+	BuildID   string `json:"build_id,omitempty"`
 }
 
 // Version returns a structure with the current version information.
@@ -56,6 +58,7 @@ func Version() Info {
 		GoVersion: goVersion,
 		BuildDate: buildDate,
 		BuildUser: buildUser,
+		BuildID:   buildID,
 	}
 }
 
@@ -73,6 +76,9 @@ func PrintFull() {
 	fmt.Printf("  revision: \t%s\n", v.Revision)
 	fmt.Printf("  build date: \t%s\n", v.BuildDate)
 	fmt.Printf("  build user: \t%s\n", v.BuildUser)
+	if v.BuildID != "" {
+		fmt.Printf("  build id: \t%s\n", v.BuildID)
+	}
 	fmt.Printf("  go version: \t%s\n", v.GoVersion)
 }
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -7,20 +7,46 @@ import (
 
 func TestVersion(t *testing.T) {
 	now := time.Now().String()
-	version = "test"
-	buildDate = now
-
-	info := Version()
-
-	if have, want := info.Version, version; have != want {
-		t.Errorf("have %s, want %s", have, want)
+	var tests = []struct {
+		version   string
+		buildDate string
+		buildID   string
+	}{
+		{
+			version:   "test",
+			buildDate: now,
+			buildID:   "42",
+		},
+		{
+			version:   "test_without_build_id",
+			buildDate: now,
+		},
 	}
 
-	if have, want := info.BuildDate, now; have != want {
-		t.Errorf("have %s, want %s", have, want)
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			version = tt.version
+			buildDate = tt.buildDate
+			buildID = tt.buildID
+
+			info := Version()
+
+			if have, want := info.Version, tt.version; have != want {
+				t.Errorf("have %s, want %s", have, want)
+			}
+
+			if have, want := info.BuildDate, tt.buildDate; have != want {
+				t.Errorf("have %s, want %s", have, want)
+			}
+
+			if have, want := info.BuildUser, "unknown"; have != want {
+				t.Errorf("have %s, want %s", have, want)
+			}
+
+			if have, want := info.BuildID, tt.buildID; have != want {
+				t.Errorf("have %s, want %s", have, want)
+			}
+		})
 	}
 
-	if have, want := info.BuildUser, "unknown"; have != want {
-		t.Errorf("have %s, want %s", have, want)
-	}
 }


### PR DESCRIPTION
If a `buildID` is set it's also printed. If not it's omitted, keeping the current version format backwards compatible. 