### PR TITLE
Some helpers for the database packages

### DIFF
--- a/dbutil/dbutil.go
+++ b/dbutil/dbutil.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
 
@@ -69,4 +70,15 @@ func OpenDB(driver, dsn string, opts ...Option) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// dbutil.OpenDBX is similar to dbutil.OpenDB, except it returns a *sqlx.DB from
+// the popular github.com/jmoiron/sqlx package.
+func OpenDBX(driver, dsn string, opts ...Option) (*sqlx.DB, error) {
+	db, err := OpenDB(driver, dsn, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening database/sql database connection")
+	}
+
+	return sqlx.NewDb(db, driver), nil
 }

--- a/pgutil/pgutil.go
+++ b/pgutil/pgutil.go
@@ -1,0 +1,26 @@
+// Package pgutil provides utilities for Postgres
+package pgutil
+
+import (
+	"fmt"
+)
+
+// ConnectionOptions represents the configurable options of a connection to a
+// Postgres database
+type ConnectionOptions struct {
+	Host     string
+	Port     string
+	User     string
+	Password string
+	DBName   string
+	SSLMode  string
+}
+
+// String implements the Stringer interface so that a pgutil.ConnectionOptions
+// can be converted into a value key/value connection string
+func (c ConnectionOptions) String() string {
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		c.Host, c.Port, c.User, c.Password, c.DBName, c.SSLMode,
+	)
+}


### PR DESCRIPTION
This PR adds 

- `dbutil.OpenDBX` which is similar to `dbutil.OpenDB` but it returns a `*sqlx.DB` instead of a `*sql.DB`
- a `pgutil.ConnectionOptions` type which implements `type Stringer interface` so that a struct of Postgres connection options can be converted into a valid key/value connection string