### PR TITLE
only use signal to swap log level on unix

### DIFF
--- a/logutil/swap_signal.go
+++ b/logutil/swap_signal.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+package logutil
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+func swapLevelHandler(base log.Logger, swapLogger *log.SwapLogger, debug bool) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGUSR2)
+	for {
+		<-sigChan
+		if debug {
+			newLogger := level.NewFilter(base, level.AllowInfo())
+			swapLogger.Swap(newLogger)
+		} else {
+			newLogger := level.NewFilter(base, level.AllowDebug())
+			swapLogger.Swap(newLogger)
+		}
+		level.Info(swapLogger).Log("msg", "swapping level", "debug", !debug)
+		debug = !debug
+	}
+}

--- a/logutil/swap_signal_windows.go
+++ b/logutil/swap_signal_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package logutil
+
+import "github.com/go-kit/kit/log"
+
+func swapLevelHandler(base log.Logger, swapLogger *log.SwapLogger, debug bool) {
+	// noop for now
+}


### PR DESCRIPTION
Windows does not have SIGUSR signals. This change allows the logger to compile on windows,
but does not implement a windows solution yet.

Still unsure what the idiomatic solution for windows is, but based on my research so far it would be using a service signal like https://github.com/golang/sys/blob/62eef0e2fa9b2c385f7b2778e763486da6880d37/windows/svc/service.go#L43 
For example, that is how the nginx daemon reloads config on SIGHUP. http://hg.nginx.org/nginx/file/tip/src/os/win32/ngx_service.c#l54

