### PR TITLE
Add file permissions to `CopyFSToDisk` util

### DIFF
--- a/fsutil/fsrecursivecopy.go
+++ b/fsutil/fsrecursivecopy.go
@@ -7,19 +7,29 @@ import (
 	"path"
 )
 
-func CopyFSToDisk(src fs.FS, destDir string) error {
-	if err := fs.WalkDir(src, ".", genCopyToDiskFunc(src, destDir)); err != nil {
+// CopyToDisk copies an embedded FS to a given directory. Because go's embed does not preserve the file mode, you must
+// also pass a function that will return the desired file mode for each file.
+func CopyFSToDisk(src fs.FS, destDir string, modeSetter func(fs.FileInfo) os.FileMode) error {
+	if err := fs.WalkDir(src, ".", genCopyToDiskFunc(src, destDir, modeSetter)); err != nil {
 		return fmt.Errorf("walking directory: %w", err)
 	}
 
 	return nil
+}
 
+// CommonFileMode is a function that returns the common file permissions: 0644 for all files, and 0755 for
+// all directories. It is provided as a helper for CopyFSToDisk's common use case
+func CommonFileMode(fi fs.FileInfo) fs.FileMode {
+	if fi.IsDir() {
+		return 0755
+	} else {
+		return 0644
+	}
 }
 
 // genCopyToDiskFunc returns fs.WalkDirFunc function that will
 // copy files to disk in a given location.
-func genCopyToDiskFunc(srcFS fs.FS, destDir string) fs.WalkDirFunc {
-
+func genCopyToDiskFunc(srcFS fs.FS, destDir string, modeSetter func(fs.FileInfo) os.FileMode) fs.WalkDirFunc {
 	return func(filepath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -34,7 +44,7 @@ func genCopyToDiskFunc(srcFS fs.FS, destDir string) fs.WalkDirFunc {
 
 		// If it's a directory, make it under destdir
 		if d.IsDir() {
-			if err := os.MkdirAll(fullpath, fileinfo.Mode()); err != nil {
+			if err := os.MkdirAll(fullpath, modeSetter(fileinfo)); err != nil {
 				return fmt.Errorf("making directory %s: %w", fullpath, err)
 			}
 			return nil
@@ -45,7 +55,7 @@ func genCopyToDiskFunc(srcFS fs.FS, destDir string) fs.WalkDirFunc {
 			return fmt.Errorf("reading file from FS %s: %w", filepath, err)
 		}
 
-		if err := os.WriteFile(fullpath, data, fileinfo.Mode()); err != nil {
+		if err := os.WriteFile(fullpath, data, modeSetter(fileinfo)); err != nil {
 			return fmt.Errorf("writing %s: %w", filepath, err)
 		}
 

--- a/fsutil/fsrecursivecopy.go
+++ b/fsutil/fsrecursivecopy.go
@@ -7,7 +7,7 @@ import (
 	"path"
 )
 
-// CopyToDisk copies an embedded FS to a given directory. Because go's embed does not preserve the file mode, you must
+// CopyFSToDisk copies an embedded FS to a given directory. Because go's embed does not preserve the file mode, you must
 // also pass a function that will return the desired file mode for each file.
 func CopyFSToDisk(src fs.FS, destDir string, modeSetter func(fs.FileInfo) os.FileMode) error {
 	if err := fs.WalkDir(src, ".", genCopyToDiskFunc(src, destDir, modeSetter)); err != nil {

--- a/fsutil/fsrecursivecopy_test.go
+++ b/fsutil/fsrecursivecopy_test.go
@@ -19,9 +19,9 @@ func TestCopyFSToDisk(t *testing.T) {
 	subdir, err := fs.Sub(embeddedSourceData, "test-data/fscopy")
 	require.NoError(t, err)
 
-	destDir := t.TempDir()
+	destDir := "/tmp/fstest" // t.TempDir()
 
-	require.NoError(t, CopyFSToDisk(subdir, destDir))
+	require.NoError(t, CopyFSToDisk(subdir, destDir, CommonFileMode))
 
 	var tests = []struct {
 		path string


### PR DESCRIPTION
As I got to use `CopyFSToDisk`, it looks like `embed` doesn't bundle any metadata. And in my quick test, it doesn't produce what I need. Seems weird, but it's how I read https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/embed/embed.go;l=216-244;drc=638c9aad5f88f96d9aa525bbe403c8a5d3b743e8

This is a fairly simple fix -- it requires we pass along a function to determine file mode. It ships a simple one for the common case.