### PR TITLE
add version number generation logic and tests

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"runtime"
+	"strconv"
+	"strings"
 )
 
 // These values are private which ensures they can only be set with the build flags.
@@ -47,6 +50,10 @@ type Info struct {
 	BuildDate string `json:"build_date"`
 	BuildUser string `json:"build_user"`
 }
+
+// semverRegexp is used to standardize various version strings by pulling out only
+// the major.minor.patch submatch
+var semverRegexp = regexp.MustCompile(`^v?([0-9]+\.[0-9]+\.[0-9]+).*$`)
 
 // Version returns a structure with the current version information.
 func Version() Info {
@@ -86,4 +93,68 @@ func Handler() http.Handler {
 		enc.SetIndent("", "  ")
 		enc.Encode(v)
 	})
+}
+
+// versionMultiplier consts are used to create a comparable and reversible integer version from a semver string
+// by using 1 million, 1 thousand, and 1 for each part we avoid collisions as long as all parts are less than 1 thousand
+const (
+	majorVersionMultiplier int = 1000000
+	minorVersionMultiplier int = 1000
+	patchVersionMultiplier int = 1
+)
+
+// VersionNum parses the semver version string to look for only the major.minor.patch portion,
+// splits that into 3 parts (disregarding any extra portions), and applies a multiplier to each
+// part to generate a total int value representing the semver.
+// note that this will generate a sortable, and reversible integer as long as all parts remain less than 1000
+// This is currently intended for use in generating comparable versions to set within windows registry entries,
+// allowing for an easy "upgrade-only" detection configuration within intune.
+// Zero is returned for any case where the version cannot be reliably translated
+func VersionNum() int {
+	semverMatch := semverRegexp.FindStringSubmatch(version)
+	// expect the leftmost match as semverMatch[0] and the semver substring as semverMatch[1]
+	if semverMatch == nil || len(semverMatch) != 2 {
+		return 0
+	}
+
+	parts := strings.Split(semverMatch[1], ".")
+	if len(parts) < 3 {
+		return 0
+	}
+
+	versionNum := 0
+	for i, part := range parts[:3] {
+		partNum, err := strconv.Atoi(part)
+		if err != nil {
+			return 0
+		}
+
+		switch i {
+		case 0:
+			versionNum += (partNum * majorVersionMultiplier)
+		case 1:
+			versionNum += (partNum * minorVersionMultiplier)
+		case 2:
+			versionNum += (partNum * patchVersionMultiplier)
+		}
+	}
+
+	return versionNum
+}
+
+// SemverFromVersionNum provides the inverse functionality of VersionNum, allowing us
+// to collect and report the integer version in a readable semver format
+func SemverFromVersionNum(versionNum int) string {
+	if versionNum == 0 {
+		return "0.0.0"
+	}
+
+	major := versionNum / majorVersionMultiplier
+	remaining := versionNum - (major * majorVersionMultiplier)
+	minor := remaining / minorVersionMultiplier
+	remaining = remaining - (minor * minorVersionMultiplier)
+	// not strictly needed because patchVersionMultiplier is 1 but here because it feels correct
+	patch := remaining * patchVersionMultiplier
+
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch)
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,8 +1,11 @@
 package version
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersion(t *testing.T) {
@@ -24,5 +27,168 @@ func TestVersion(t *testing.T) {
 
 	if have, want := info.BuildUser, "unknown"; have != want {
 		t.Errorf("have %s, want %s", have, want)
+	}
+}
+
+func Test_VersionNum(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		semver             string
+		expectedVersionNum int
+	}{
+		"empty version": {
+			semver:             "",
+			expectedVersionNum: 0,
+		},
+		"basic version": {
+			semver:             "1.2.3",
+			expectedVersionNum: 1002003,
+		},
+		"max version": {
+			semver:             "999.999.999",
+			expectedVersionNum: 999999999,
+		},
+		"semver with leading v": {
+			semver:             "v1.1.2",
+			expectedVersionNum: 1001002,
+		},
+		"semver with leading zeros": {
+			semver:             "01.01.002",
+			expectedVersionNum: 1001002,
+		},
+		"semver with trailing branch info": {
+			semver:             "1.10.3-1-g98Paoe",
+			expectedVersionNum: 1010003,
+		},
+		"semver with leading v and trailing branch info": {
+			semver:             "v1.10.3-1-g98Paoe",
+			expectedVersionNum: 1010003,
+		},
+		"zero version": {
+			semver:             "0.0.0",
+			expectedVersionNum: 0,
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			version = tt.semver
+			require.Equal(t, tt.expectedVersionNum, VersionNum())
+		})
+	}
+}
+
+func Test_SemverFromVersionNum(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		versionNum     int
+		expectedSemver string
+	}{
+		"zero version": {
+			versionNum:     0,
+			expectedSemver: "0.0.0",
+		},
+		"1.10.3": {
+			versionNum:     1010003,
+			expectedSemver: "1.10.3",
+		},
+		"max version": {
+			versionNum:     999999999,
+			expectedSemver: "999.999.999",
+		},
+		"1.112.43": {
+			versionNum:     1112043,
+			expectedSemver: "1.112.43",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expectedSemver, SemverFromVersionNum(tt.versionNum))
+		})
+	}
+}
+
+func Test_VersionNumComparisons(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		lesserVersion  string
+		greaterVersion string
+	}{
+		"empty version": {
+			lesserVersion:  "",
+			greaterVersion: "0.0.1",
+		},
+		"basic versions": {
+			lesserVersion:  "1.2.3",
+			greaterVersion: "1.2.4",
+		},
+		"max versions": {
+			lesserVersion:  "999.999.998",
+			greaterVersion: "999.999.999",
+		},
+		"large minor versions, no collisions": {
+			lesserVersion:  "v1.999.999",
+			greaterVersion: "v2.0.0",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			version = tt.lesserVersion
+			lesserParsed := VersionNum()
+			version = tt.greaterVersion
+			greaterParsed := VersionNum()
+			require.True(t, lesserParsed < greaterParsed,
+				fmt.Sprintf("expected %s to parse as lesser than %s. got lesser %d >= greater %d",
+					tt.lesserVersion,
+					tt.greaterVersion,
+					lesserParsed,
+					greaterParsed,
+				),
+			)
+		})
+	}
+}
+
+func Test_VersionNumIsReversible(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		testedVersion string
+	}{
+		"zero version": {
+			testedVersion: "0.0.0",
+		},
+		"basic version": {
+			testedVersion: "1.2.3",
+		},
+		"max version": {
+			testedVersion: "999.999.999",
+		},
+		"random version": {
+			testedVersion: "107.61.10",
+		},
+		"random version 2": {
+			testedVersion: "0.118.919",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			version = tt.testedVersion
+			require.Equal(t, tt.testedVersion, SemverFromVersionNum(VersionNum()))
+		})
 	}
 }


### PR DESCRIPTION
We need to be able to generate an integer value from our semver versioning strings. The value generated will be added to windows registry to assist with intune detection rules. We will add the built version automatically on MSI install, as well as set an additional key on startup with the currently running version after autoupdates.

I imagine we'll want to add this information to flares at some point too, so a helper function to translate the integer version back to a semver string is also included

For additional context see issue [here](https://github.com/kolide/k2/issues/10843) 