### PR TITLE
update golangci.yml to remove deprecation warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 run:
-  skip-dirs:
-    - test-cmds
   timeout: 5m
 
 linters:
@@ -18,16 +16,12 @@ linters:
     - gosec
     - gosimple
     - ineffassign
-    - interfacer
-    - maligned
     - noctx
     - staticcheck
-    - structcheck
-    - varcheck
 
 linters-settings:
   errcheck:
-    ignore: github.com/go-kit/kit/log:Log
+    exclude-functions: github.com/go-kit/kit/log:Log
   gofmt:
     simplify: false
 
@@ -37,3 +31,5 @@ issues:
     - linters:
       - paralleltest
       text: "does not use range value in test Run"
+  exclude-dirs:
+    - test-cmds


### PR DESCRIPTION
this updates .golangci.yml to prevent the following warnings:

```
zackolson:kit❱ golangci-lint run
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
WARN [lintersdb] The linter "interfacer" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
WARN [lintersdb] The linter "maligned" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
WARN [lintersdb] The linter "structcheck" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
WARN [lintersdb] The linter "varcheck" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
```
