### PR TITLE
add VersionNumFromSemver for builds

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -103,15 +103,17 @@ const (
 	patchVersionMultiplier int = 1
 )
 
-// VersionNum parses the semver version string to look for only the major.minor.patch portion,
+// VersionNumFromSemver parses the semver version string to look for only the major.minor.patch portion,
 // splits that into 3 parts (disregarding any extra portions), and applies a multiplier to each
 // part to generate a total int value representing the semver.
 // note that this will generate a sortable, and reversible integer as long as all parts remain less than 1000
 // This is currently intended for use in generating comparable versions to set within windows registry entries,
 // allowing for an easy "upgrade-only" detection configuration within intune.
-// Zero is returned for any case where the version cannot be reliably translated
-func VersionNum() int {
-	semverMatch := semverRegexp.FindStringSubmatch(version)
+// Zero is returned for any case where the version cannot be reliably translated.
+// VersionNumFromSemver should be used where the build time version value cannot be controlled- to restrict
+// translations to the internally set version, use VersionNum
+func VersionNumFromSemver(semver string) int {
+	semverMatch := semverRegexp.FindStringSubmatch(semver)
 	// expect the leftmost match as semverMatch[0] and the semver substring as semverMatch[1]
 	if semverMatch == nil || len(semverMatch) != 2 {
 		return 0
@@ -140,6 +142,13 @@ func VersionNum() int {
 	}
 
 	return versionNum
+}
+
+// VersionNum returns an integer representing the version value set at build time.
+// see VersionNumFromSemver for additional details regarding the general translation process
+// and limitations. this will return 0 if version is unset/unknown
+func VersionNum() int {
+	return VersionNumFromSemver(version)
 }
 
 // SemverFromVersionNum provides the inverse functionality of VersionNum, allowing us

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -41,8 +41,16 @@ func Test_VersionNum(t *testing.T) {
 			semver:             "",
 			expectedVersionNum: 0,
 		},
+		"unset version": {
+			semver:             "unknown",
+			expectedVersionNum: 0,
+		},
 		"basic version": {
 			semver:             "1.2.3",
+			expectedVersionNum: 1002003,
+		},
+		"4_part_version": {
+			semver:             "1.2.3.4",
 			expectedVersionNum: 1002003,
 		},
 		"max version": {


### PR DESCRIPTION
This builds on the existing `VersionNum` logic to add an additional `VersionNumFromSemver` utility function. While `VersionNum` works well when the version is known at build time, our build process also needs to be able to use this functionality without setting the required version value for building this package. To support both cases, `VersionNumFromSemver` will use identical logic, but allow passing in a semver string instead of relying on the internal version variable value