### PR TITLE
Upgrade to go 1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           skip-save-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,95 +1,112 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
     - bodyclose
     - containedctx
-    - gofmt
-    - govet
-    - ineffassign
+    - exhaustive
+    - gocritic
     - misspell
+    - nakedret
     - noctx
     - perfsprint
+    - predeclared
+    - revive
     - rowserrcheck
     - sloglint
     - sqlclosecheck
-    - staticcheck
-    - usetesting
     - unconvert
-    - unused
-    - gocritic
-    - nakedret
-    - predeclared
-    - revive
-    - exhaustive
+    - usetesting
   disable:
     - errcheck
     - gosec
-    - gosimple
-
-linters-settings:
-  errcheck:
-    exclude-functions: [github.com/go-kit/kit/log:Log]
-  gofmt:
-    simplify: false
-  gocritic:
-    disabled-checks:
-      - ifElseChain
-      - elseif
-  sloglint:
-    kv-only: true
-    context: "all"
-    key-naming-case: snake
-    static-msg: true
-  revive:
+  settings:
+    errcheck:
+      exclude-functions:
+        - github.com/go-kit/kit/log:Log
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - elseif
+    revive:
+      rules:
+        - name: superfluous-else
+          arguments:
+            - preserveScope
+          severity: warning
+          disabled: false
+        - name: package-comments
+          disabled: false
+        - name: context-as-argument
+          disabled: false
+        - name: context-keys-type
+          disabled: false
+        - name: error-return
+          disabled: false
+        - name: errorf
+          disabled: false
+        - name: unreachable-code
+          disabled: false
+        - name: early-return
+          disabled: false
+        - name: confusing-naming
+          disabled: false
+        - name: defer
+          disabled: false
+    sloglint:
+      kv-only: true
+      context: all
+      static-msg: true
+      key-naming-case: snake
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: superfluous-else
-        severity: warning
-        disabled: false
-        arguments:
-          - "preserveScope"
-      - name: package-comments
-        disabled: false
-      - name: context-as-argument
-        disabled: false
-      - name: context-keys-type
-        disabled: false
-      - name: error-return
-        disabled: false
-      - name: errorf
-        disabled: false
-      - name: unreachable-code
-        disabled: false
-      - name: early-return
-        disabled: false
-      - name: confusing-naming
-        disabled: false
-      - name: defer
-        disabled: false
-  staticcheck:
-    checks: ["all"]
-
-issues:
-  exclude-rules:
-    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
-    - linters:
-        - paralleltest
-      text: "does not use range value in test Run"
-    # We prefer fmt.Sprintf over string concatenation for readability
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with string concatenation"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster hex.EncodeToString"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.FormatBool"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.FormatInt"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.FormatUint"
-    - linters: [perfsprint]
-      text: "fmt.Sprintf can be replaced with faster strconv.Itoa"
-    - linters: [perfsprint]
-      text: "fmt.Sprint can be replaced with faster strconv.Itoa"
-  exclude-dirs:
-    - test-cmds
+      - linters:
+          - paralleltest
+        text: does not use range value in test Run
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with string concatenation
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster hex.EncodeToString
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.FormatBool
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.FormatInt
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.FormatUint
+      - linters:
+          - perfsprint
+        text: fmt.Sprintf can be replaced with faster strconv.Itoa
+      - linters:
+          - perfsprint
+        text: fmt.Sprint can be replaced with faster strconv.Itoa
+    paths:
+      - test-cmds
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: lax
+    paths:
+      - test-cmds
+      - third_party$
+      - builtin$
+      - examples$

--- a/dbutil/dbutil.go
+++ b/dbutil/dbutil.go
@@ -88,7 +88,7 @@ func OpenDB(driver, dsn string, opts ...Option) (*sql.DB, error) {
 
 	var dbError error
 	for attempt := 0; attempt < config.maxAttempts; attempt++ {
-		dbError = db.Ping()
+		dbError = db.Ping() //nolint:noctx
 		if dbError == nil {
 			// we're connected!
 			break

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -82,7 +82,7 @@ func StartServer(opts ...Option) (*Server, error) {
 }
 
 func (s *Server) Start() error {
-	l, err := net.Listen("tcp", s.addr)
+	l, err := net.Listen("tcp", s.addr) //nolint:noctx
 	if err != nil {
 		return errors.Wrap(err, "opening socket")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kolide/kit
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -62,7 +62,7 @@ func TestHealthzHandler(t *testing.T) {
 			t.Parallel()
 
 			rr := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/healthz", nil)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "/healthz", nil)
 			tt.handler.ServeHTTP(rr, req)
 			assert.Equal(t, rr.Code, tt.wantHeader)
 		})

--- a/munemo/munemo.go
+++ b/munemo/munemo.go
@@ -116,11 +116,7 @@ func (m *munemo) decode(s string) error {
 
 	// As long as there are characters, parse them
 	// Read the first syllable, interpret, remove.
-	for {
-		if s == "" {
-			break
-		}
-
+	for s != "" {
 		// Syllables are 2 or 3 letters. Check to see if the first 2 or 3
 		// characters are in our array of syllables.
 		if val, ok := m.symbolValues[s[0:2]]; ok {


### PR DESCRIPTION
Upgrading to golang 1.25 requires an upgrade to golangci-lint version, which requires an upgrade to golangci-lint v2 specifically. Same as https://github.com/kolide/launcher/pull/2528.

Migration guide: https://golangci-lint.run/docs/product/migration-guide/