### PR TITLE
ci: pin versions to shas, configure dependabot for actions, go 1.25 -> 1.26.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
           go-version-file: './go.mod'
           check-latest: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
           check-latest: true
           cache: false
       - name: install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
       - name: actionlint
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kolide/kit
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc


### PR DESCRIPTION
[KOL-786](https://1password.atlassian.net/browse/KOL-786)

GitHub hardening docs [recommend pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions).

Changes:
  - Lock down actionlint and govulncheck to specific sha.
  - Configure dependabot for GitHub actions.
  - Bump to go 1.26.5 for GO-2026-5856.
